### PR TITLE
Improve overall decryption script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # deshc
 Shell Script to decrypt SHC
 
+> [!IMPORTANT]
 > Due to Android user complaining about shebang because system hiearchy problem, I recommend you to run it via shell instead of treating it as an executable
 
 ```sh
@@ -14,7 +15,7 @@ Multiple files are supported
 
 # SECURITY 
 This shell script still execute in the machine. I still configuring it by using `prlimit --pid <pid> --nofile=X` so it can only open the shared library.
-Give time with `sleep 0.01` until it calls `execve` and then send `SIGSTOP` signal after that so atleast the shell script isn't running while being decrypted.
+Give time with `sleep 0.07` until it calls `execve` and then send `SIGSTOP` signal after that so atleast the shell script isn't running while being decrypted.
 
 # How does it work?
 SHC works internally called `execve` to shell, it decrypted at runtimes and visible via command line args process

--- a/deshc.sh
+++ b/deshc.sh
@@ -1,9 +1,17 @@
 #!/bin/sh
-for arg in $@
-do
-  $arg > /dev/null & child=$!
-  sleep 0.01
-  kill -STOP $child
-  cat /proc/$child/cmdline | sed 's/.*\(#!\)/\1/; $d' > $arg.dec.sh
-  kill -TERM $child
+
+bin_dir="$(dirname "$(readlink -f "$(which sh)")")"
+
+for arg in $@; do
+	if [ -f $arg ] || [ -f $bin_dir/$arg ]; then
+		$arg >/dev/null 2>&1 &
+		child=$!
+		sleep 0.07
+
+		kill -STOP $child
+		cat /proc/$child/cmdline | sed 's/.*\(#!\)/\1/; $d' >$arg.dec.sh
+		kill -TERM $child
+	else
+		echo "error: file $arg not found."
+	fi
 done


### PR DESCRIPTION
- Add error handler
  Verify binary from user input is exist.

- Delay 0.07s until it calls execve
  sleep 0.01 isn't enough, bunch scripts and devices combination haven't call execve in that time
  resuling empty decrypt output.

- Add `2>&1` to silence binary output
  Besides completely silence output from binary, this also will fix some binary that stuck
  (can't be killed) while decryption.